### PR TITLE
Add annotations to enable prometheus scraping

### DIFF
--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -63,6 +63,8 @@ func deployment(es *egressv1.ExternalService, configHash string) *appsv1.Deploym
 	a := annotations(es)
 	a["egress.monzo.com/config-hash"] = configHash
 	a["egress.monzo.com/admin-port"] = strconv.Itoa(int(adPort))
+	a["prometheus.io/port"] = "11000"
+	a["prometheus.io/scrape"] = "true"
 
 	var resources corev1.ResourceRequirements
 	if es.Spec.Resources != nil {


### PR DESCRIPTION
Envoy admin interface is exposed at 11000. This annotation will instruct
Prometheus to scrape matching pods within Monzo's infrastructure.