### PR TITLE
Add sensible TCP access logging

### DIFF
--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -79,6 +79,9 @@ func adminPort(es *egressv1.ExternalService) int32 {
 	panic("couldn't find a port for admin listener")
 }
 
+const accessLogFormat = `[%START_TIME%] %BYTES_RECEIVED% %BYTES_SENT% %DURATION% "%DOWNSTREAM_REMOTE_ADDRESS%" "%UPSTREAM_HOST%"
+`
+
 func envoyConfig(es *egressv1.ExternalService) (string, error) {
 	config := bootstrapv2.Bootstrap{
 		Node: &envoycorev2.Node{
@@ -131,6 +134,9 @@ func envoyConfig(es *egressv1.ExternalService) (string, error) {
 		switch protocol {
 		case envoycorev2.SocketAddress_TCP:
 			accessConfig, err := ptypes.MarshalAny(&accesslogv2.FileAccessLog{
+				AccessLogFormat: &accesslogv2.FileAccessLog_Format{
+					Format: accessLogFormat,
+				},
 				Path: "/dev/stdout",
 			})
 

--- a/controllers/configmap_test.go
+++ b/controllers/configmap_test.go
@@ -76,6 +76,8 @@ staticResources:
           - name: envoy.file_access_log
             typedConfig:
               '@type': type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+              format: |
+                [%START_TIME%] %BYTES_RECEIVED% %BYTES_SENT% %DURATION% "%DOWNSTREAM_REMOTE_ADDRESS%" "%UPSTREAM_HOST%"
               path: /dev/stdout
           cluster: foo_TCP_101
           statPrefix: tcp_proxy


### PR DESCRIPTION
Instead of the default log line which has a bunch of headers and no
source, we should log the source ip