### PR TITLE
Add envoy metrics tags to identify cluster_name and pod nature

### DIFF
--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -14,6 +14,7 @@ import (
 	accesslogfilterv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
 	tcpproxyv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	udpproxyv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/udp/udp_proxy/v2alpha"
+	metricsv2 "github.com/envoyproxy/go-control-plane/envoy/config/metrics/v2"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/duration"
@@ -197,6 +198,21 @@ func envoyConfig(es *egressv1.ExternalService) (string, error) {
 
 		config.StaticResources.Clusters = append(config.StaticResources.Clusters, cluster)
 		config.StaticResources.Listeners = append(config.StaticResources.Listeners, listener)
+	}
+
+	config.StatsConfig.StatsTags = []*metricsv2.TagSpecifier{
+		{
+			TagName: "cluster_name",
+			TagValue: &metricsv2.TagSpecifier_FixedValue{
+				FixedValue: es.Name,
+			},
+		},
+		{
+			TagName: "is_egress_gateway",
+			TagValue: &metricsv2.TagSpecifier_FixedValue{
+				FixedValue: "true",
+			},
+		},
 	}
 
 	m := &jsonpb.Marshaler{}

--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -208,7 +208,7 @@ func envoyConfig(es *egressv1.ExternalService) (string, error) {
 			},
 		},
 		{
-			TagName: "is_egress_gateway",
+			TagName: "egress_operator_managed",
 			TagValue: &metricsv2.TagSpecifier_FixedValue{
 				FixedValue: "true",
 			},


### PR DESCRIPTION
Envoy pods managed by `egress-operator` previously didn't emit metrics identifying the envoy cluster name, nor the fact that these envoy pods act as egress gateways. Exporting these information help distinguishing proxy envoy pods managed by `egress-operator` from those used for microservice meshes in metrics.