### PR TITLE
Disable CGO during build time to fix #14

### DIFF
--- a/coredns-plugin/Makefile
+++ b/coredns-plugin/Makefile
@@ -7,4 +7,4 @@ docker-push:
 	docker push ${IMG}
 
 build:
-	GOOS=linux GOARCH=amd64 go build -o coredns ./cmd
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o coredns ./cmd


### PR DESCRIPTION
We don't need to link CGO during build time as CoreDNS itself does not require it. This should fix build issues in #14

https://github.com/coredns/coredns/blob/master/Makefile#L16