### PR TITLE
Update default lease duration and renew deadline

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	egressv1 "github.com/monzo/egress-operator/api/v1"
 	"github.com/monzo/egress-operator/controllers"
@@ -32,6 +33,10 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	// see https://github.com/operator-framework/operator-sdk/issues/1813
+	leaseDuration = 30 * time.Second
+	renewDeadline = 20 * time.Second
 )
 
 const namespace = "egress-operator-system"
@@ -59,6 +64,8 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaseDuration:      &leaseDuration,
+		RenewDeadline:      &renewDeadline,
 		Port:               9443,
 		Namespace:          namespace,
 	})


### PR DESCRIPTION
We often get alerts about the controller manager exiting:

<img width="699" alt="Screenshot 2021-04-29 at 11 40 13" src="https://user-images.githubusercontent.com/19717495/116538815-efd7c200-a8df-11eb-8443-e9c64184cd0a.png">

Investigating the logs we see:
```
2021-04-29T10:12:51.869Z	ERROR	setup	problem running manager	{"error": "leader election lost"}
github.com/go-logr/zapr.(*zapLogger).Error
	/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
main.main
	/workspace/main.go:82
runtime.main
	/usr/local/go/src/runtime/proc.go:203
```

But this is interesting as we run the controller manager as a singleton so it should never loose the leadership 🤔 Some investigation found this ticket: https://github.com/operator-framework/operator-sdk/issues/1813.

This PR updates the config values mentioned in that ticket to see if that helps, prior to deeper investigation
