### PR TITLE
Add ability to set static IP addresses for the clusters

### DIFF
--- a/api/v1/externalservice_types.go
+++ b/api/v1/externalservice_types.go
@@ -53,6 +53,10 @@ type ExternalServiceSpec struct {
 	// If true, add a `egress.monzo.com/hijack-dns: true` label to produced Service objects
 	// CoreDNS can watch this label and decide to rewrite DnsName -> clusterIP
 	HijackDns bool `json:"hijackDns,omitempty"`
+
+	// When set allows overwriting the A records of the DNS being overridden.
+	// +optional
+	IpOverride []string `json:"ipOverride,omitempty"`
 }
 
 type ExternalServicePort struct {

--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -148,6 +148,9 @@ func envoyConfig(es *egressv1.ExternalService) (string, error) {
 					},
 				})
 			}
+			cluster.ClusterDiscoveryType = &envoyv2.Cluster_Type{
+				Type: envoyv2.Cluster_STATIC,
+			}
 		}
 
 		var listener *envoyv2.Listener

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/golang/protobuf/proto"
-	egressv1 "github.com/monzo/egress-operator/api/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -14,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	egressv1 "github.com/monzo/egress-operator/api/v1"
 )
 
 // +kubebuilder:rbac:namespace=egress-operator-system,groups=apps,resources=deployments,verbs=get;list;watch;create;patch

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-cmp v0.3.0
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
+	golang.org/x/sys v0.0.0-20220817070843-5a390386f1f2 // indirect
 	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f h1:25KHgbfyiSm6vwQLbM3zZIe1v9p/3ea4Rz+nnM5K/i4=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220817070843-5a390386f1f2 h1:fqTvyMIIj+HRzMmnzr9NtpHP6uVpvB5fkHcgPDC4nu8=
+golang.org/x/sys v0.0.0-20220817070843-5a390386f1f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Add the ability to overwrite the IP addresses of clusters. This means something going via the egress-operator can have it's traffic routed down private connections instead of publicly over the internet when needed.

Example usage:
```
apiVersion: egress.monzo.com/v1
kind: ExternalService
metadata:
  name: test.example.com
spec:
  dnsName: test.example.com
  hijackDns: true
  ports:
    - port: 443
  ipOverride:
  - "10.11.12.13"
  - "10.11.12.14"
```

Use the egress operator for `test.example.com` but when creating the envoy clusters set the IP to the static values