### PR TITLE
controllers/configmap: Configure upstream TCP keepalives

### DIFF
--- a/controllers/configmap_test.go
+++ b/controllers/configmap_test.go
@@ -47,6 +47,11 @@ staticResources:
                 protocol: UDP
     name: foo_UDP_100
     type: LOGICAL_DNS
+    upstreamConnectionOptions:
+      tcpKeepalive:
+        keepaliveInterval: 5
+        keepaliveProbes: 3
+        keepaliveTime: 30
   - connectTimeout: 1s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
@@ -60,6 +65,11 @@ staticResources:
                 portValue: 101
     name: foo_TCP_101
     type: LOGICAL_DNS
+    upstreamConnectionOptions:
+      tcpKeepalive:
+        keepaliveInterval: 5
+        keepaliveProbes: 3
+        keepaliveTime: 30
   listeners:
   - address:
       socketAddress:


### PR DESCRIPTION
We noticed a high background rate of TCP RSTs after we added a high volume egress gateway internally - we tracked this down to the lack of TCP keepalives being sent from egress gateways to upstream sites. Many public servers have quite aggressive (<5m) keepalive settings which means that when we're proxying a persistent connection that doesn't send data for a while, the upstream will close the connection, then send a RST if we then try to send data. We fix this just by configuring Envoy to send keepalives to hold the connection open.