### PR TITLE
Create PDBs for egress gateways

### DIFF
--- a/controllers/externalservice_controller.go
+++ b/controllers/externalservice_controller.go
@@ -38,6 +38,8 @@ type ExternalServiceReconciler struct {
 	client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
+
+	EnablePodDisruptionBudgets bool
 }
 
 // +kubebuilder:rbac:groups=egress.monzo.com,resources=externalservices,verbs=get;list;watch;create;update;patch;delete
@@ -86,9 +88,11 @@ func (r *ExternalServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	if err := r.reconcilePodDisruptionBudget(ctx, req, es); err != nil {
-		log.Error(err, "unable to reconcile PodDisruptionBudget")
-		return ctrl.Result{}, err
+	if r.EnablePodDisruptionBudgets {
+		if err := r.reconcilePodDisruptionBudget(ctx, req, es); err != nil {
+			log.Error(err, "unable to reconcile PodDisruptionBudget")
+			return ctrl.Result{}, err
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/externalservice_controller.go
+++ b/controllers/externalservice_controller.go
@@ -86,6 +86,11 @@ func (r *ExternalServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
+	if err := r.reconcilePodDisruptionBudget(ctx, req, es); err != nil {
+		log.Error(err, "unable to reconcile PodDisruptionBudget")
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/externalservice_controller_test.go
+++ b/controllers/externalservice_controller_test.go
@@ -15,7 +15,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -203,13 +203,13 @@ func assertState(key types.NamespacedName, es *v1.ExternalService) {
 		assertLabels(autoscaler(es)),
 	))
 
-	Eventually(func() *policyv1beta1.PodDisruptionBudget {
-		p := &policyv1beta1.PodDisruptionBudget{}
+	Eventually(func() *policyv1.PodDisruptionBudget {
+		p := &policyv1.PodDisruptionBudget{}
 		_ = k8sClient.Get(context.Background(), key, p)
 
 		return p
 	}, timeout, interval).Should(And(
-		WithTransform(func(d *policyv1beta1.PodDisruptionBudget) policyv1beta1.PodDisruptionBudgetSpec {
+		WithTransform(func(d *policyv1.PodDisruptionBudget) policyv1.PodDisruptionBudgetSpec {
 			return d.Spec
 		}, Equal(pdb(es).Spec)),
 		assertOwner(key.Name),

--- a/controllers/externalservice_controller_test.go
+++ b/controllers/externalservice_controller_test.go
@@ -15,6 +15,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -200,5 +201,18 @@ func assertState(key types.NamespacedName, es *v1.ExternalService) {
 		}, Equal(autoscaler(es).Spec)),
 		assertOwner(key.Name),
 		assertLabels(autoscaler(es)),
+	))
+
+	Eventually(func() *policyv1beta1.PodDisruptionBudget {
+		p := &policyv1beta1.PodDisruptionBudget{}
+		_ = k8sClient.Get(context.Background(), key, p)
+
+		return p
+	}, timeout, interval).Should(And(
+		WithTransform(func(d *policyv1beta1.PodDisruptionBudget) policyv1beta1.PodDisruptionBudgetSpec {
+			return d.Spec
+		}, Equal(pdb(es).Spec)),
+		assertOwner(key.Name),
+		assertLabels(pdb(es)),
 	))
 }

--- a/controllers/poddisruptionbudget.go
+++ b/controllers/poddisruptionbudget.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	egressv1 "github.com/monzo/egress-operator/api/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -18,7 +18,7 @@ func (r *ExternalServiceReconciler) reconcilePodDisruptionBudget(ctx context.Con
 		return err
 	}
 
-	pdb := &policyv1beta1.PodDisruptionBudget{}
+	pdb := &policyv1.PodDisruptionBudget{}
 	if err := r.Get(ctx, req.NamespacedName, pdb); err != nil {
 		if apierrs.IsNotFound(err) {
 			return r.Client.Create(ctx, desired)
@@ -34,15 +34,15 @@ func (r *ExternalServiceReconciler) reconcilePodDisruptionBudget(ctx context.Con
 	return ignoreNotFound(r.patchIfNecessary(ctx, patched, client.MergeFrom(pdb)))
 }
 
-func pdb(es *egressv1.ExternalService) *policyv1beta1.PodDisruptionBudget {
-	return &policyv1beta1.PodDisruptionBudget{
+func pdb(es *egressv1.ExternalService) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        es.Name,
 			Namespace:   namespace,
 			Labels:      labels(es),
 			Annotations: annotations(es),
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels(es),
 			},

--- a/controllers/poddisruptionbudget.go
+++ b/controllers/poddisruptionbudget.go
@@ -1,0 +1,55 @@
+package controllers
+
+import (
+	"context"
+
+	egressv1 "github.com/monzo/egress-operator/api/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (r *ExternalServiceReconciler) reconcilePodDisruptionBudget(ctx context.Context, req ctrl.Request, es *egressv1.ExternalService) error {
+	desired := pdb(es)
+	if err := ctrl.SetControllerReference(es, desired, r.Scheme); err != nil {
+		return err
+	}
+
+	pdb := &policyv1beta1.PodDisruptionBudget{}
+	if err := r.Get(ctx, req.NamespacedName, pdb); err != nil {
+		if apierrs.IsNotFound(err) {
+			return r.Client.Create(ctx, desired)
+		}
+		return err
+	}
+
+	patched := pdb.DeepCopy()
+	mergeMap(desired.Labels, patched.Labels)
+	mergeMap(desired.Annotations, patched.Annotations)
+	patched.Spec = desired.Spec
+
+	return ignoreNotFound(r.patchIfNecessary(ctx, patched, client.MergeFrom(pdb)))
+}
+
+func pdb(es *egressv1.ExternalService) *policyv1beta1.PodDisruptionBudget {
+	return &policyv1beta1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        es.Name,
+			Namespace:   namespace,
+			Labels:      labels(es),
+			Annotations: annotations(es),
+		},
+		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels(es),
+			},
+			MaxUnavailable: &intstr.IntOrString{
+				Type:   intstr.String,
+				StrVal: "25%",
+			},
+		},
+	}
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -74,9 +74,10 @@ var _ = BeforeSuite(func(done Done) {
 	})
 
 	err = (&ExternalServiceReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ExternalService"),
-		Scheme: scheme.Scheme,
+		Client:                     k8sManager.GetClient(),
+		Log:                        ctrl.Log.WithName("controllers").WithName("ExternalService"),
+		Scheme:                     scheme.Scheme,
+		EnablePodDisruptionBudgets: true,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -49,11 +49,16 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
+	var (
+		metricsAddr                string
+		enableLeaderElection       bool
+		enablePodDisruptionBudgets bool
+	)
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&enablePodDisruptionBudgets, "enable-pod-disruption-budgets", false,
+		"Enable deploying pod disruption budgets for egress gateways.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
@@ -76,9 +81,10 @@ func main() {
 	}
 
 	if err = (&controllers.ExternalServiceReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ExternalService"),
-		Scheme: mgr.GetScheme(),
+		Client:                     mgr.GetClient(),
+		Log:                        ctrl.Log.WithName("controllers").WithName("ExternalService"),
+		Scheme:                     mgr.GetScheme(),
+		EnablePodDisruptionBudgets: enablePodDisruptionBudgets,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ExternalService")
 		os.Exit(1)


### PR DESCRIPTION
Turns out we're not creating PodDisruptionBudgets for egress-gateways, which means that their pods can be evicted into unavailability.