### PR TITLE
Add the ability to set max skew per external service

### DIFF
--- a/api/v1/externalservice_types.go
+++ b/api/v1/externalservice_types.go
@@ -89,6 +89,13 @@ type ExternalServiceSpec struct {
 	// Defaults to false
 	// +optional
 	JsonClusterAccessLogs bool `json:"envoyJsonClusterAccessLogs,omitempty"`
+
+	// TopologySpreadSkews is a struct that allows overriding the topology spread skews for the service
+	// +optional
+	TopologySpreadSkews struct {
+		Zone     int `json:"zone,omitempty"`
+		Hostname int `json:"hostname,omitempty"`
+	} `json:"topologySpreadSkews,omitempty"`
 }
 
 type ExternalServicePort struct {

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -111,10 +111,17 @@ func deployment(es *egressv1.ExternalService, configHash string) *appsv1.Deploym
 		zoneKey, zoneKeyFound := os.LookupEnv("POD_TOPOLOGY_ZONE_MAX_SKEW_KEY")
 		zoneWhenUnsatisfiable, zoneWhenUnsatisfiableFound := os.LookupEnv("POD_TOPOLOGY_ZONE_WHEN_UNSATISFIABLE")
 		if zoneEnabled {
-			maxSkew, err := strconv.Atoi(zoneSkew)
-			if err != nil {
-				maxSkew = 1
+			maxSkew := 1
+			if es.Spec.TopologySpreadSkews.Zone != 0 {
+				maxSkew = es.Spec.TopologySpreadSkews.Zone
+			} else {
+				var err error
+				maxSkew, err = strconv.Atoi(zoneSkew)
+				if err != nil {
+					maxSkew = 1
+				}
 			}
+
 			// Default zone key to the Kubernetes topology one if not specified
 			if !zoneKeyFound {
 				zoneKey = "topology.kubernetes.io/zone"
@@ -133,10 +140,17 @@ func deployment(es *egressv1.ExternalService, configHash string) *appsv1.Deploym
 		hostnameKey, hostnameKeyFound := os.LookupEnv("POD_TOPOLOGY_HOSTNAME_MAX_SKEW_KEY")
 		hostnameWhenUnsatisfiable, hostnameWhenUnsatisfiableFound := os.LookupEnv("POD_TOPOLOGY_HOSTNAME_WHEN_UNSATISFIABLE")
 		if hostnameEnabled {
-			maxSkew, err := strconv.Atoi(hostnameSkew)
-			if err != nil {
-				maxSkew = 1
+			maxSkew := 1
+			if es.Spec.TopologySpreadSkews.Hostname != 0 {
+				maxSkew = es.Spec.TopologySpreadSkews.Hostname
+			} else {
+				var err error
+				maxSkew, err = strconv.Atoi(hostnameSkew)
+				if err != nil {
+					maxSkew = 1
+				}
 			}
+
 			// Default zone key to the Kubernetes topology one if not specified
 			if !hostnameKeyFound {
 				hostnameKey = "kubernetes.io/hostname"


### PR DESCRIPTION
We want the ability to configure the topology spread max skew on individual services for times when we don't mind more then 1 pod per node (say we have more replicas then nodes).

This allows you to set it per ExternalService, falling back to the same logic (use env var or default to `1` if that fails) as before.

