### PR TITLE
Fix incorrect CIDR in egress gateway NetworkPolicy

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
         - 172.16.0.0/12
         - 192.0.0.0/24
         - 192.168.0.0/16
-        - 192.18.0.0/15
+        - 198.18.0.0/15
   podSelector:
     matchLabels:
       app: "egress-gateway"


### PR DESCRIPTION
## Summary

The `public-egress` NetworkPolicy in `config/manager/manager.yaml` excludes `192.18.0.0/15` from allowed egress traffic. This is a digit transposition — the intended range is `198.18.0.0/15` (RFC 2544 benchmarking, IANA reserved).

- **`192.18.0.0/15`** (`192.18.0.0 – 192.19.255.255`) is routable public IP space allocated by ARIN (currently Oracle). Blocking this range incorrectly denies egress to legitimate destinations.
- **`198.18.0.0/15`** (`198.18.0.0 – 198.19.255.255`) is the RFC 2544 benchmarking range, reserved by IANA and not globally reachable. This is what should be excluded alongside the other non-public ranges in the list.

Every other entry in the except list is a correct non-public range (RFC 1918, RFC 6598, loopback, link-local, IETF protocol assignments). This is the only one that doesn't match its intended reservation.

## References

- [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry)
- [RFC 2544 — Benchmarking Methodology for Network Interconnect Devices](https://www.rfc-editor.org/rfc/rfc2544)
- [RFC 6890 — Special-Purpose IP Address Registries](https://www.rfc-editor.org/rfc/rfc6890)